### PR TITLE
Fixes a parse error by removing a semicolon

### DIFF
--- a/lib/wundernode.js
+++ b/lib/wundernode.js
@@ -38,7 +38,7 @@ var wundernode = function(apikey, debug, rateCount, rateTime) {
          
            // remainingRequests tells us how many additional requests could be sent
            // right this moment
-           console.log('running limited request' + limiter.getTokensRemaining(););         
+           console.log('running limited request' + limiter.getTokensRemaining());         
            request(url, function (error, response, body) {
                   if (!error && response.statusCode == 200) {
                   if (debug) console.log('response body: ' + body);


### PR DESCRIPTION
Just fixing what was probably a typo. This is a crashing bug in something I'm working on.
