### PR TITLE
Imports api key from config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 node_modules/*
+/config/development.js

--- a/Example.js
+++ b/Example.js
@@ -8,7 +8,7 @@
 // git: www.github.com/evalcrux
 // Changes by lgriffin include defintion of country and city
 // Imports
-
+var config = require('./config/development');
 // Changes by bacall213 include clarification on how to use the Wundernode client,
 // including removal of unused city and country variables, and an example query.
 
@@ -16,8 +16,6 @@ var WunderNodeClient = require("wundernode");
 var URL = require('url');
 // Definitions
 
-// Replace this with your API KEY
-var apikey = "12345";
 
 // Location is passed to the Wunderground API via the query returned by Express
 // Example query: http://127.0.0.1:3000/conditions?New York,NY
@@ -27,7 +25,7 @@ var apikey = "12345";
 var debug = false;
 
 // Create Client
-var wunder = new WunderNodeClient(apikey, debug,  10, 'minute');
+var wunder = new WunderNodeClient(config.api, debug,  10, 'minute');
 
 var express = require('express');
 

--- a/config/development.sample.js
+++ b/config/development.sample.js
@@ -1,0 +1,5 @@
+var config ={}
+
+config.api ="";
+
+module.exports=config;


### PR DESCRIPTION
Having the api key like that is just bad form, we should just import it from a config file.  This will make it easier to manage the API key, as well as manage other keys in the project