### PR TITLE
Adding formatting and debug to log statements

### DIFF
--- a/lib/wundernode.js
+++ b/lib/wundernode.js
@@ -16,20 +16,25 @@ var rateTime = 'minute';
 var limiter = new RateLimiter(rateCount, rateTime);
 
 var wundernode = function (apikey, debug, rateCount, rateTime) {
+    var log = function (message) {
+        if (debug) {
+            console.log('WunderNode: ' + message);
+        }
+    };
     if (rateCount && rateTime) {
-        console.log('reseting rate : ' + rateCount + ' per ' + rateTime);
+        log('reseting rate : ' + rateCount + ' per ' + rateTime);
         limiter = new RateLimiter(rateCount, rateTime);
     }
     var that = this;
     var format = ".json";
-    console.log('WunderNodeClient initialized, apikey: ' + apikey + ', debug enbaled: ' + debug + ', rateCount: ' + rateCount + ', rateTime: ' + rateTime);
+    log('client initialized, apikey: ' + apikey + ', debug enabled: ' + debug + ', rateCount: ' + rateCount + ', rateTime: ' + rateTime);
 
     var host = 'http://api.wunderground.com/api/' + apikey;
 
-    if (debug) console.log('Host: ' + host);
+    log('host: ' + host);
     var get = function (callback, params, path) {
         var url = host + path;
-        if (debug) console.log('get: ' + url);
+        log('get: ' + url);
 
         // Throttle requests
         limiter.removeTokens(1, function (err, callbacks) {
@@ -38,10 +43,10 @@ var wundernode = function (apikey, debug, rateCount, rateTime) {
 
             // remainingRequests tells us how many additional requests could be sent
             // right this moment
-            console.log('running limited request' + limiter.getTokensRemaining());
+            log('running limited request ' + limiter.getTokensRemaining());
             request(url, function (error, response, body) {
                 if (!error && response.statusCode == 200) {
-                    if (debug) console.log('response body: ' + body);
+                    log('response body: ' + body);
                     try {
                         body = JSON.parse(body);
                         callback(error, body);
@@ -51,7 +56,7 @@ var wundernode = function (apikey, debug, rateCount, rateTime) {
                     }
                 }
                 else if (error) {
-                    console.log('error: ' + err);
+                    log('error: ' + err);
                 }
 
             });


### PR DESCRIPTION
Suggest using a common log function that prepends something indicating the message originates from WunderNode. Make all log statements read from the debug flag instead of just some- especially the one spitting out the API key to the console.