### PR TITLE
Ensure wundernode returns errors on failed requests

### DIFF
--- a/lib/wundernode.js
+++ b/lib/wundernode.js
@@ -44,14 +44,22 @@ var wundernode = function (apikey, rateCount, rateTime, debug) {
                     if (debug) console.log('response body: ' + body);
                     try {
                         body = JSON.parse(body);
-                        callback(error, body);
+                        callback(null, body);
                     }
                     catch (err) {
                         callback("Invalid JSON response", body);
                     }
-                }
-                else if (error) {
-                    console.log('error: ' + err);
+                } else {
+                    if (debug) {
+                        var statusInfo = response && response.statusCode ? 'status code: ' + response.statusCode : 'no response';
+                        console.log('error: ' + (error || statusInfo));
+                    }
+                    try {
+                        body = JSON.parse(body);
+                    } catch (parseErr) {
+                        // body may not be JSON; return as-is
+                    }
+                    callback(error || new Error('Request failed'), body);
                 }
 
             });


### PR DESCRIPTION
## Summary
- always invoke callback when a request fails and surface the error
- log actual error or status code when requests are unsuccessful

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cde4ba0108323b55a686c5ddab9c9